### PR TITLE
Fix Misaligned Border-Bottom on Selected Tab with Divider in Tabs Component

### DIFF
--- a/src/Tabs/Tab/styles.js
+++ b/src/Tabs/Tab/styles.js
@@ -12,7 +12,7 @@ const StyledTab = styled.li`
       theme?.text?.[appearance]?.content.color.regular ||
       inube.text[appearance].content.color.regular
     }`};
-
+  padding-bottom: 4px;
   & > p {
     cursor: ${({ disabled }) => (disabled ? "not-allowed" : "pointer")};
   }

--- a/src/Tabs/index.tsx
+++ b/src/Tabs/index.tsx
@@ -23,7 +23,7 @@ const Tabs = ({ tabs, onChange, scroll = false, selectedTab }: ITabs) => {
 
   return (
     <StyledContainer>
-      <Stack justifyContent="space-between" gap="12px">
+      <Stack justifyContent="space-between" gap="12px" height="32px">
         {scroll && (
           <Icon
             variant="filled"

--- a/src/Tabs/styles.js
+++ b/src/Tabs/styles.js
@@ -7,6 +7,7 @@ const StyledTabs = styled.div`
   overflow-x: hidden;
   white-space: nowrap;
   width: 100%;
+  align-content: flex-end;
   & > div {
     width: fit-content;
   }
@@ -24,6 +25,9 @@ const StyledContainer = styled.div`
   border-bottom: 2px solid
     ${({ theme }) => theme?.palette?.neutral?.N40 || inube.palette.neutral.N40};
   padding: 0 16px;
+  & > div > figure {
+    padding-top: 4px;
+  }
 `;
 
 export { StyledTabs, StyledContainer };


### PR DESCRIPTION
This pull request addresses an issue where the border-bottom of the selected tab does not align properly with the divider of the entire tabs component. The fix ensures that the selected tab's border-bottom is correctly aligned, providing a consistent and visually appealing appearance across the tabs.