### PR TITLE
Move tabs tokens from foundations to component

### DIFF
--- a/src/Tabs/Tab/index.tsx
+++ b/src/Tabs/Tab/index.tsx
@@ -1,8 +1,8 @@
-import { Text } from "@inubekit/text";
+import { Text, TextTokens } from "@inubekit/text";
 import { StyledTab } from "./styles";
-import { inube } from "@inubekit/foundations";
 import { useContext } from "react";
 import { ThemeContext } from "styled-components";
+import { tokens } from "../Tokens/tokens";
 
 interface ITab {
   label: string;
@@ -13,10 +13,10 @@ interface ITab {
 
 const Tab = (props: ITab) => {
   const { disabled = false, selected = false, id, label } = props;
-  const theme: typeof inube = useContext(ThemeContext);
+  const theme = useContext(ThemeContext) as { tabs: typeof tokens };
   const selectedAppearance =
     theme?.tabs?.content?.appearance?.selected ||
-    inube.tabs.content.appearance.selected;
+    tokens.content.appearance.selected;
 
   return (
     <StyledTab
@@ -29,7 +29,7 @@ const Tab = (props: ITab) => {
         type="label"
         size="medium"
         appearance={
-          selected ? (selectedAppearance as keyof typeof inube.text) : "gray"
+          selected ? (selectedAppearance as keyof typeof TextTokens) : "gray"
         }
         disabled={disabled}
         textAlign="start"

--- a/src/Tabs/Tab/styles.js
+++ b/src/Tabs/Tab/styles.js
@@ -1,5 +1,5 @@
-import { inube } from "@inubekit/foundations";
 import styled from "styled-components";
+import { TextTokens } from "@inubekit/text";
 
 const StyledTab = styled.li`
   width: fit-content;
@@ -10,7 +10,7 @@ const StyledTab = styled.li`
     !disabled &&
     `4px solid ${
       theme?.text?.[appearance]?.content.color.regular ||
-      inube.text[appearance].content.color.regular
+      TextTokens[appearance].content.color.regular
     }`};
   padding-bottom: 4px;
   & > p {

--- a/src/Tabs/Tokens/tokens.ts
+++ b/src/Tabs/Tokens/tokens.ts
@@ -1,0 +1,9 @@
+const tokens = {
+  content: {
+    appearance: {
+      selected: "primary",
+    },
+  },
+};
+
+export { tokens };

--- a/src/Tabs/stories/Tabs.stories.tsx
+++ b/src/Tabs/stories/Tabs.stories.tsx
@@ -34,7 +34,6 @@ Default.args = {
   ],
   selectedTab: "generalInformation",
   scroll: true,
-  showChevrons: true,
 };
 
 export { Default };

--- a/src/Tabs/styles.js
+++ b/src/Tabs/styles.js
@@ -1,5 +1,4 @@
 import styled from "styled-components";
-
 import { inube } from "@inubekit/foundations";
 
 const StyledTabs = styled.div`


### PR DESCRIPTION
This PR relocates the tabs tokens from the foundations folder to the component folder, updating all relevant imports to reflect the new structure and ensuring that components reference the correct token paths. This change improves the organization, maintainability, and clarity of the codebase.